### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/backend/messaging.py
+++ b/backend/messaging.py
@@ -220,7 +220,10 @@ def delete_message(request, message_id, room_id):
                 )
         return Response("message not found", status=status.HTTP_404_NOT_FOUND)
     except Exception as e:
-        return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.error("An error occurred while deleting a message", exc_info=True)
+        return Response("An internal error occurred.", status=status.HTTP_400_BAD_REQUEST)
 
 
 @swagger_auto_schema(


### PR DESCRIPTION
Potential fix for [https://github.com/zxenonx/zc_plugin_dm/security/code-scanning/5](https://github.com/zxenonx/zc_plugin_dm/security/code-scanning/5)

To fix the issue, we will replace the direct exposure of the exception message (`str(e)`) with a generic error message for the user. The detailed exception information will be logged on the server for debugging purposes. This ensures that sensitive information is not exposed to the user while still allowing developers to diagnose issues.

Steps to implement the fix:
1. Replace the `Response(str(e), ...)` line with a generic error message for the user, such as `"An internal error occurred."`.
2. Log the exception details (`e`) on the server using a logging mechanism. If no logging is set up, we can use Python's built-in `logging` module.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace raw exception message in delete_message response with a generic error and log exception details server-side